### PR TITLE
changed home page route to show watchlists/3

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   get "nocansee", to: "static_pages#nocansee"
   get "results", to: "static_pages#results"
 
-  root 'movies#index'
+  #root 'movies#index'
+  root :to => 'watchlists#show', :id => '3'
 
 end


### PR DESCRIPTION
i just changed the routing so that when we go to the homepage, it is the Both watchlist show page. it seemed a little unruly to have all 3 of our watchlists up there.